### PR TITLE
Fix/check job interface after instantiation

### DIFF
--- a/bin/queue.php
+++ b/bin/queue.php
@@ -17,13 +17,14 @@ use Vanilla\QueueWorker\QueueWorker;
 
 // Switch to queue root
 chdir(dirname($argv[0]));
+$DIR = getcwd();
 
 // Include the core autoloader.
 
 $paths = [
-    __DIR__.'/vendor/autoload.php',     // symlinked bin
-    __DIR__.'/../vendor/autoload.php',  // locally
-    __DIR__.'/../../../autoload.php'    // dependency
+    $DIR.'/vendor/autoload.php',     // symlinked bin
+    $DIR.'/../vendor/autoload.php',  // locally
+    $DIR.'/../../../autoload.php'    // dependency
 ];
 foreach ($paths as $path) {
     if (file_exists($path)) {
@@ -33,7 +34,7 @@ foreach ($paths as $path) {
 }
 
 // Run bootstrap
-QueueWorker::bootstrap(__DIR__);
+QueueWorker::bootstrap($DIR);
 
 $exitCode = 0;
 try {

--- a/src/Worker/ProductWorker.php
+++ b/src/Worker/ProductWorker.php
@@ -390,13 +390,14 @@ class ProductWorker extends AbstractQueueWorker {
             throw new UnknownJobException($message, "specified job class cannot be found");
         }
 
+        // Create job instance
+        $job = $workerDI->get($payloadType);
+
         // Check that the job is legal
-        if (!is_a($payloadType, JobInterface::class, true)) {
+        if (!$job instanceof JobInterface) {
             throw new BrokenJobException($message, "specified job class does not implement JobInterface");
         }
 
-        // Create job instance
-        $job = $workerDI->get($payloadType);
         $job->setID($message->getID());
         $job->setData($message->getBody());
         return $job;


### PR DESCRIPTION
### bin/queue.php 
+ Use of getcwd() instead of __DIR__; I was getting issues with symlinks and __DIR__ in a container environment.

### src/Worker/ProductWorker.php
+ Improve the verification of the JobInterface implementation